### PR TITLE
Bump min PHP version to 8.3

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -13,12 +13,8 @@ jobs:
       max-parallel: 3
       matrix:
         php:
-          - 7.3
-          - 7.4
-          - 8.0
-          - 8.1
-          - 8.2
           - 8.3
+          - 8.4
         composer: 
           - 2  
     name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Smarty plugin that adds some image related template syntax enchaments",
     "type": "library",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.3",
         "imponeer/smarty-extensions-contracts": "^3.0",
         "intervention/image": "^2.5",
         "psr/cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
Resolve #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated PHP version requirements to 8.3 or higher.
  - Adjusted automated testing to only include PHP 8.3 and 8.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->